### PR TITLE
fix: use the lowest supportable version of System.Text.Json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "System.Text.Json"
     groups:
       all:
         patterns:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <!-- Project packages -->
   <ItemGroup>
-    <PackageVersion Include="System.Text.Json" Version="8.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
   <!-- Test packages -->


### PR DESCRIPTION
This increases compatability by working with any version
 of `System.Text.Json` starting from the lowest
 supportable version `6.0.0`